### PR TITLE
Feature/3 put command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ In ephemeral branches like `env/dev`, features are to always be merged in with `
 
 ## An example
 
+
+### Listing merges
+
 Here is some broken down output of a development branch when running `git-smash -l debug list` (debug to see what's going on under the hood):
 
 Run the program:
@@ -75,6 +78,9 @@ INFO 	5eaa71173c114ea826909124c628ff435659ba96 Merge branch 'feature/1031' into 
 INFO 	c073b813b78202b8647eb1c514ca48837a87cd4e Merge branch 'feature/update-rows' into env/dev-ad-api
 INFO 	248efcf99b96eaf2a7f667c5ce94162ef632d1e3 Merge branch 'feature/public-access' into env/dev-ad-api
 ```
+
+
+### Replaying
 
 This is already looking much cleaner than before.  Now, the magic; replaying the cleaned up list.  Breaking down the `git-smash replay` command, as before it finds where to begin:
 
@@ -138,3 +144,35 @@ c5fdfe29a1d4acf0de02dc1d2fedfac9f195302d Merge branch 'feature/public-access' in
 ```
 
 Replaying multiple times will result in the same content, however git will re-generate commit hashes.
+
+
+## Putting Feature branches
+
+When working on a feature branch the `put` command can be used to apply it to an ephemeral branch.  For instance, starting with an ephemeral branch containing ponies and unicorns:
+
+```
+[0][~/Projects/thing(feature/th-1234-unicorns:aea2079)]
+$ git-smash put env/dev-thing
+INFO src=feature/th-1234-unicorns
+INFO git checkout env/dev-thing
+Switched to branch 'env/dev-thing'
+INFO git merge feature/th-1234-unicorns
+Already up to date.
+INFO git-smash replay
+INFO find merge commits:
+INFO looking for merge commits until df3ebc54c13ec5bcd3e78c338abc06434eb653c1
+INFO branches to merge:
+	348909114a586b43d0904accb26ecf76fa7d723f @ experiments/ponies
+	aea20795f5e60a1018460a13f69ae170ac5c83b0 @ feature/th-1234-unicorns
+INFO backing up current branch to smash/env/dev-thing
+smash/env/dev-thing already exists; remove it? [Y|n]: y
+INFO remove 8e97ffc647a8f219d1565804f42ffcf99d09a932 @ smash/env/dev-thing
+INFO resetting env/dev-thing to df3ebc54c13ec5bcd3e78c338abc06434eb653c1 @ origin/master
+INFO merging 348909114a586b43d0904accb26ecf76fa7d723f @ experiments/ponies
+INFO merging aea20795f5e60a1018460a13f69ae170ac5c83b0 @ feature/th-1234-unicorns
+INFO git checkout -
+Switched to branch 'feature/th-1234-unicorns'
+Your branch is up to date with 'rca/feature/th-1234-unicorns'.
+```
+
+Additionally, `--push` can be added to automatically push a successful replay upstream.

--- a/src/git_smash/entrypoints.py
+++ b/src/git_smash/entrypoints.py
@@ -23,7 +23,7 @@ def git_smash():
     )
     parser.add_argument("action", help="the action to take")
 
-    args = parser.parse_args()
+    args, remainder = parser.parse_known_args()
 
     loglevel = getattr(logging, args.loglevel.upper())
     log_format = "%(levelname)s %(message)s"
@@ -38,4 +38,4 @@ def git_smash():
     if not fn:
         sys.exit(f"ERROR: action {args.action} not defined")
 
-    sys.exit(fn())
+    sys.exit(fn(*remainder))

--- a/src/git_smash/entrypoints.py
+++ b/src/git_smash/entrypoints.py
@@ -17,6 +17,7 @@ def git_smash():
         help="automatically clean the backup smash branch",
     )
     parser.add_argument("--drop", action="append", help="drop the given branches")
+    parser.add_argument("--push", action="store_true", help="push the result upstream")
     parser.add_argument(
         "--reset-base", action="store_true", help="reset the branch to the base branch"
     )
@@ -31,7 +32,7 @@ def git_smash():
     # drop sh logging
     logger = logging.getLogger("sh").setLevel(logging.WARNING)
 
-    smash = Smash(clean_backups=args.clean, drop_branches=args.drop)
+    smash = Smash(clean_backups=args.clean, drop_branches=args.drop, push=args.push)
 
     fn = getattr(smash, args.action, None)
     if not fn:

--- a/src/git_smash/smash.py
+++ b/src/git_smash/smash.py
@@ -18,11 +18,13 @@ class Smash:
         self,
         clean_backups: bool = True,
         drop_branches: List[str] = None,
+        push: bool = False,
         base_branch: str = "origin/master",
     ):
         self.base_branch_name = base_branch
         self.clean_backups = clean_backups
         self.drop_branches = drop_branches
+        self.push = push  # whether to push upstream
 
     def apply_branch(self, branch, merge_commit=None):
         """Attempt to merge the found branch,  name or fallback to the merge commit"""

--- a/src/git_smash/smash.py
+++ b/src/git_smash/smash.py
@@ -130,6 +130,30 @@ class Smash:
         """Returns the master revison"""
         return run_command(f"git rev-list {self.base_branch_name} --max-count 1")
 
+    def put(self, *args):
+        # when only one path is given, the arg is the destination branch
+        if len(args) == 1:
+            src, dest = ".", args[0]
+        else:
+            src, dest = args
+
+        if src == ".":
+            branch_manager = git.get_branch_manager()
+            src = branch_manager.get_current_branch()
+
+            self.logger.info(f"src={src}")
+
+        commands = [f"git checkout {dest}", f"git merge {src}", f"git-smash replay"]
+
+        if self.push:
+            commands.append(f"git push --force-with-lease")
+
+        commands.append(f"git checkout -")
+
+        for command in commands:
+            self.logger.info(command)
+            run_command(command, _fg=True)
+
     def replay(self):
         on_base = self.base_rev == self.master_rev
         if not on_base:

--- a/src/git_smash/utils.py
+++ b/src/git_smash/utils.py
@@ -14,10 +14,10 @@ def get_proc(command: str, **kwargs):
     return sh_command(*command_split[1:], **kwargs)
 
 
-def run_command(command: str) -> str:
-    proc = get_proc(command)
-
-    return proc.stdout.decode("utf8").strip()
+def run_command(command: str, **kwargs) -> str:
+    proc = get_proc(command, **kwargs)
+    if proc:
+        return proc.stdout.decode("utf8").strip()
 
 
 def run_command_with_interactive_fallback(command: str, message: str = None):


### PR DESCRIPTION
When working on a feature branch

```
[0][~/Projects/thing(feature/th-1234-unicorns:aea2079)]
$ git-smash put env/dev-thing
INFO src=feature/th-1234-unicorns
INFO git checkout env/dev-thing
Switched to branch 'env/dev-thing'
INFO git merge feature/th-1234-unicorns
Already up to date.
INFO git-smash replay
INFO find merge commits:
INFO looking for merge commits until df3ebc54c13ec5bcd3e78c338abc06434eb653c1
INFO branches to merge:
	348909114a586b43d0904accb26ecf76fa7d723f @ experiments/ponies
	aea20795f5e60a1018460a13f69ae170ac5c83b0 @ feature/th-1234-unicorns
INFO backing up current branch to smash/env/dev-thing
smash/env/dev-thing already exists; remove it? [Y|n]: y
INFO remove 8e97ffc647a8f219d1565804f42ffcf99d09a932 @ smash/env/dev-thing
INFO resetting env/dev-thing to df3ebc54c13ec5bcd3e78c338abc06434eb653c1 @ origin/master
INFO merging 348909114a586b43d0904accb26ecf76fa7d723f @ experiments/ponies
INFO merging aea20795f5e60a1018460a13f69ae170ac5c83b0 @ feature/th-1234-unicorns
INFO git checkout -
Switched to branch 'feature/th-1234-unicorns'
Your branch is up to date with 'rca/feature/th-1234-unicorns'.
```

It's also possible to call `git smash put env/dev-thing --push` and have the merged branch pushed after a successful replay.